### PR TITLE
Fix cost model

### DIFF
--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -103,6 +103,7 @@ impl Lookup {
 struct Permutation {
     chunk_len: usize,
     columns: usize,
+    /// Number of usable rows. See [here](https://zcash.github.io/halo2/design/proving-system/permutation.html#zero-knowledge-adjustment)
     u: isize,
 }
 
@@ -183,9 +184,8 @@ impl CostOptions {
         // - SCALAR bytes per fixed per query <- missing
         // - SCALAR bytes per permutation column
         // - 5 * SCALAR bytes per lookup argument
-        let nb_perm_chunks = ((self.permutation.columns.saturating_sub(1))
-            / (self.max_degree.saturating_sub(2)))
-            + 1;
+        let nb_perm_chunks =
+            (self.permutation.columns.saturating_sub(1) / self.max_degree.saturating_sub(2)) + 1;
         let plonk = comp_bytes(1, 0) * self.advice.len()
             + self
                 .advice

--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -23,50 +23,50 @@ use super::{CellValue, Region};
 
 /// Options to build a circuit specification to measure the cost model of.
 #[derive(Debug)]
-pub struct CostOptions {
+struct CostOptions {
     /// An advice column with the given rotations. May be repeated.
-    pub advice: Vec<Poly>,
+    advice: Vec<Poly>,
 
     /// An instance column with the given rotations. May be repeated.
-    pub instance: Vec<Poly>,
+    instance: Vec<Poly>,
 
     /// A fixed column with the given rotations. May be repeated.
-    pub fixed: Vec<Poly>,
+    fixed: Vec<Poly>,
 
     /// Maximum degree of the custom gates.
-    pub gate_degree: usize,
+    gate_degree: usize,
 
     /// Maximum degree of the constraint system.
-    pub max_degree: usize,
+    max_degree: usize,
 
     /// A lookup over N columns with max input degree I and max table degree T. May be repeated.
-    pub lookup: Vec<Lookup>,
+    lookup: Vec<Lookup>,
 
     /// A permutation over N columns. May be repeated.
-    pub permutation: Permutation,
+    permutation: Permutation,
 
     /// 2^K bound on the number of rows, accounting for ZK, PIs and Lookup tables.
-    pub min_k: usize,
+    min_k: usize,
 
     /// Rows count, not including table rows and not accounting for compression
     /// (where multiple regions can use the same rows).
-    pub rows_count: usize,
+    rows_count: usize,
 
     /// Table rows count, not accounting for compression (where multiple regions
     /// can use the same rows), but not much if any compression can happen with
     /// table rows anyway.
-    pub table_rows_count: usize,
+    table_rows_count: usize,
 
     /// Compressed rows count, accounting for compression (where multiple
     /// regions can use the same rows).
-    pub compressed_rows_count: usize,
+    compressed_rows_count: usize,
 }
 
 /// Structure holding polynomial related data for benchmarks
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Poly {
+struct Poly {
     /// Rotations for the given polynomial
-    pub rotations: Vec<isize>,
+    rotations: Vec<isize>,
 }
 
 impl FromStr for Poly {
@@ -82,11 +82,11 @@ impl FromStr for Poly {
 
 /// Structure holding the Lookup related data for circuit benchmarks.
 #[derive(Debug, Clone)]
-pub struct Lookup;
+struct Lookup;
 
 impl Lookup {
     /// Returns the queries of the lookup argument
-    pub fn queries(&self) -> impl Iterator<Item = Poly> {
+    fn queries(&self) -> impl Iterator<Item = Poly> {
         // - product commitments at x and \omega x
         // - input commitments at x and x_inv
         // - table commitments at x
@@ -103,13 +103,13 @@ impl Lookup {
 
 /// Number of permutation enabled columns
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Permutation {
+struct Permutation {
     columns: usize,
 }
 
 impl Permutation {
     /// Returns the queries of the Permutation argument
-    pub fn queries(&self) -> impl Iterator<Item = Poly> {
+    fn queries(&self) -> impl Iterator<Item = Poly> {
         // - product commitments at x and x_inv
         // - polynomial commitments at x
         let product = "0,-1".parse().unwrap();
@@ -121,7 +121,7 @@ impl Permutation {
     }
 
     /// Returns the number of columns of the Permutation argument
-    pub fn nr_columns(&self) -> usize {
+    fn nr_columns(&self) -> usize {
         self.columns
     }
 }
@@ -139,9 +139,12 @@ pub struct CircuitModel {
     pub max_deg: usize,
     /// Number of advice columns.
     pub advice_columns: usize,
-    /// Number of lookup arguments.
+    /// Number of fixed columns. This includes selectors, tables (for lookups), and permutation
+    /// commitments.
+    pub fixed_columns: usize,
+    /// Number of advice columns used in the lookup argument.
     pub lookups: usize,
-    /// Equality constraint enabled columns.
+    /// Equality constraint enabled columns (fixed columns are counted in `fixed_columns` value).
     pub permutations: usize,
     /// Number of distinct column queries across all gates.
     pub column_queries: usize,
@@ -154,7 +157,7 @@ pub struct CircuitModel {
 impl CostOptions {
     /// Convert [CostOptions] to [CircuitModel]. The proof sizè is computed depending on the base
     /// and scalar field size of the curve used, together with the [CommitmentScheme].
-    pub fn into_circuit_model<const COMM: usize, const SCALAR: usize>(&self) -> CircuitModel {
+    fn into_circuit_model<const COMM: usize, const SCALAR: usize>(&self) -> CircuitModel {
         let mut queries: Vec<_> = iter::empty()
             .chain(self.advice.iter())
             .chain(self.instance.iter())
@@ -174,24 +177,34 @@ impl CostOptions {
 
         // PLONK:
         // - COMM bytes (commitment) per advice column
-        // - 3 * COMM bytes (commitments) + 5 * SCALAR bytes (evals) per lookup column
-        // - COMM bytes (commitment) + 2 * SCALAR bytes (evals) per permutation argument
-        // - COMM bytes (eval) per column per permutation argument
+        // - 3 * COMM bytes per lookup
+        // - COMM bytes per ((self.permutation.columns - 1) / (self.max_degree - 2)) + 1
+        // - 3 * SCALAR bytes per ((self.permutation.columns - 1) / (self.max_degree - 2)) + 1
+        // - SCALAR bytes per advice per query
+        // - SCALAR bytes per fixed per query <- missing
+        // - SCALAR bytes per permutation column
+        // - 5 * SCALAR bytes per lookup argument
+        let nb_perm_chunks = ((self.permutation.columns - 1) / (self.max_degree - 2)) + 1;
         let plonk = comp_bytes(1, 0) * self.advice.len()
+            + self.advice.iter().map(|polys| comp_bytes(0, polys.rotations.len())).sum::<usize>()
+            + self.fixed.iter().map(|polys| comp_bytes(0, polys.rotations.len())).sum::<usize>()
             + comp_bytes(3, 5) * self.lookup.len()
-            + comp_bytes(1, 2 + self.permutation.columns);
+            + comp_bytes(1, 3) * nb_perm_chunks
+            + comp_bytes(0, 1) * self.permutation.columns;
 
         // Vanishing argument:
-        // - (max_deg - 1) * COMM bytes (commitments) + (max_deg - 1) * SCALAR bytes (h_evals)
-        //   for quotient polynomial
-        // - SCALAR bytes (eval) per column query
+        // - COMM bytes for random poly
+        // - (max_deg - 1) COMM bytes for the pieces
+        // - (max_deg - 1) * SCALAR bytes for pieces eval
+        // - SCALAR bytes for random piece eval
         let vanishing =
-            comp_bytes(self.max_degree - 1, self.max_degree - 1) + comp_bytes(0, column_queries);
+            comp_bytes(self.max_degree, self.max_degree);
 
         // Multiopening argument:
-        // - f_commitment (COMM bytes)
-        // - SCALAR bytes (evals) per set of points in multiopen argument
-        let multiopen = comp_bytes(1, point_sets);
+        // - COMM bytes for f_commitment
+        // - SCALAR bytes per set of points in multiopen argument
+        // - COMM bytes for proof
+        let multiopen = comp_bytes(2, point_sets);
 
         let mut nr_rotations = HashSet::new();
         for poly in self.advice.iter() {
@@ -204,11 +217,7 @@ impl CostOptions {
             nr_rotations.extend(poly.rotations.clone());
         }
 
-        // Polycommit GWC:
-        // - number_rotations * COMM bytes
-        let polycomm = comp_bytes(nr_rotations.len(), 0);
-
-        let size = plonk + vanishing + multiopen + polycomm;
+        let size = plonk + vanishing + multiopen;
 
         CircuitModel {
             k: self.min_k,
@@ -216,6 +225,8 @@ impl CostOptions {
             table_rows: self.table_rows_count,
             max_deg: self.max_degree,
             advice_columns: self.advice.len(),
+            // Note that we have one fixed commitment per column in the permutation argument
+            fixed_columns: self.fixed.len() + self.permutation.columns,
             lookups: self.lookup.len(),
             permutations: self.permutation.columns,
             column_queries,
@@ -242,7 +253,7 @@ pub fn from_circuit_to_circuit_model<
 
 /// Given a circuit, this function returns [CostOptions]. If no upper bound for `k` is
 /// provided, we iterate until a valid `k` is found (this might delay the computation).
-pub fn from_circuit_to_cost_model_options<F: Ord + Field + FromUniformBytes<64>, C: Circuit<F>>(
+fn from_circuit_to_cost_model_options<F: Ord + Field + FromUniformBytes<64>, C: Circuit<F>>(
     k_upper_bound: Option<u32>,
     circuit: &C,
     nb_instances: usize,

--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -186,8 +186,16 @@ impl CostOptions {
         // - 5 * SCALAR bytes per lookup argument
         let nb_perm_chunks = ((self.permutation.columns - 1) / (self.max_degree - 2)) + 1;
         let plonk = comp_bytes(1, 0) * self.advice.len()
-            + self.advice.iter().map(|polys| comp_bytes(0, polys.rotations.len())).sum::<usize>()
-            + self.fixed.iter().map(|polys| comp_bytes(0, polys.rotations.len())).sum::<usize>()
+            + self
+                .advice
+                .iter()
+                .map(|polys| comp_bytes(0, polys.rotations.len()))
+                .sum::<usize>()
+            + self
+                .fixed
+                .iter()
+                .map(|polys| comp_bytes(0, polys.rotations.len()))
+                .sum::<usize>()
             + comp_bytes(3, 5) * self.lookup.len()
             + comp_bytes(1, 3) * nb_perm_chunks
             + comp_bytes(0, 1) * self.permutation.columns;
@@ -197,8 +205,7 @@ impl CostOptions {
         // - (max_deg - 1) COMM bytes for the pieces
         // - (max_deg - 1) * SCALAR bytes for pieces eval
         // - SCALAR bytes for random piece eval
-        let vanishing =
-            comp_bytes(self.max_degree, self.max_degree);
+        let vanishing = comp_bytes(self.max_degree, self.max_degree);
 
         // Multiopening argument:
         // - COMM bytes for f_commitment

--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -707,3 +707,195 @@ impl<F: Field> Assignment<F> for DevAssembly<F> {
         // Do nothing; we don't care about namespaces in this context.
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::{Layouter, SimpleFloorPlanner};
+    use crate::plonk::{create_proof, keygen_pk, keygen_vk_with_k};
+    use crate::plonk::{Expression, Fixed, TableColumn};
+    use crate::poly::kzg::params::ParamsKZG;
+    use crate::poly::kzg::KZGCommitmentScheme;
+    use crate::poly::Rotation;
+    use crate::transcript::{CircuitTranscript, Transcript};
+    use blake2b_simd::State;
+    use blstrs::{Bls12, Scalar};
+    use rand_core::{OsRng, RngCore};
+
+    #[derive(Clone, Copy)]
+    struct StandardPlonkConfig {
+        a: Column<Advice>,
+        b: Column<Advice>,
+        c: Column<Advice>,
+        q_a: Column<Fixed>,
+        q_b: Column<Fixed>,
+        q_c: Column<Fixed>,
+        q_ab: Column<Fixed>,
+        constant: Column<Fixed>,
+        instance: Column<Instance>,
+        table_selector: Selector,
+        table: TableColumn,
+    }
+
+    impl StandardPlonkConfig {
+        fn configure(meta: &mut ConstraintSystem<Scalar>) -> Self {
+            let [a, b, c] = std::array::from_fn(|_| meta.advice_column());
+            let [q_a, q_b, q_c, q_ab, constant] = std::array::from_fn(|_| meta.fixed_column());
+            let instance = meta.instance_column();
+
+            [a, b, c].map(|column| meta.enable_equality(column));
+
+            let table_selector = meta.complex_selector();
+            let sl = meta.lookup_table_column();
+
+            meta.lookup("lookup", |meta| {
+                let selector = meta.query_selector(table_selector);
+                let not_selector = Expression::Constant(Scalar::ONE) - selector.clone();
+                let advice = meta.query_advice(a, Rotation::cur());
+                vec![(selector * advice + not_selector, sl)]
+            });
+
+            meta.create_gate(
+                "q_a·a + q_b·b + q_c·c + q_ab·a·b + constant + instance = 0",
+                |meta| {
+                    let [a, b, c] =
+                        [a, b, c].map(|column| meta.query_advice(column, Rotation::cur()));
+                    let [q_a, q_b, q_c, q_ab, constant] = [q_a, q_b, q_c, q_ab, constant]
+                        .map(|column| meta.query_fixed(column, Rotation::cur()));
+                    let instance = meta.query_instance(instance, Rotation::cur());
+                    Some(
+                        q_a * a.clone()
+                            + q_b * b.clone()
+                            + q_c * c
+                            + q_ab * a * b
+                            + constant
+                            + instance,
+                    )
+                },
+            );
+
+            StandardPlonkConfig {
+                a,
+                b,
+                c,
+                q_a,
+                q_b,
+                q_c,
+                q_ab,
+                constant,
+                instance,
+                table_selector,
+                table: sl,
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct StandardPlonk(Scalar);
+
+    impl Circuit<Scalar> for StandardPlonk {
+        type Config = StandardPlonkConfig;
+        type FloorPlanner = SimpleFloorPlanner;
+        #[cfg(feature = "circuit-params")]
+        type Params = ();
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<Scalar>) -> Self::Config {
+            StandardPlonkConfig::configure(meta)
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<Scalar>,
+        ) -> Result<(), Error> {
+            layouter.assign_table(
+                || "8-bit table",
+                |mut table| {
+                    for row in 0u64..(1 << 8) {
+                        table.assign_cell(
+                            || format!("row {row}"),
+                            config.table,
+                            row as usize,
+                            || Value::known(Scalar::from(row + 1)),
+                        )?;
+                    }
+
+                    Ok(())
+                },
+            )?;
+
+            layouter.assign_region(
+                || "",
+                |mut region| {
+                    config.table_selector.enable(&mut region, 0)?;
+                    region.assign_advice(|| "", config.a, 0, || Value::known(self.0))?;
+                    region.assign_fixed(|| "", config.q_a, 0, || Value::known(-Scalar::ONE))?;
+
+                    region.assign_advice(
+                        || "",
+                        config.a,
+                        1,
+                        || Value::known(-Scalar::from(5u64)),
+                    )?;
+                    for (idx, column) in (1..).zip([
+                        config.q_a,
+                        config.q_b,
+                        config.q_c,
+                        config.q_ab,
+                        config.constant,
+                    ]) {
+                        region.assign_fixed(
+                            || "",
+                            column,
+                            1,
+                            || Value::known(Scalar::from(idx as u64)),
+                        )?;
+                    }
+
+                    let a =
+                        region.assign_advice(|| "", config.a, 2, || Value::known(Scalar::ONE))?;
+                    a.copy_advice(|| "", &mut region, config.b, 3)?;
+                    a.copy_advice(|| "", &mut region, config.c, 4)?;
+                    Ok(())
+                },
+            )
+        }
+    }
+
+    #[test]
+    fn cost_model() {
+        let k = 9;
+        let mut random_byte = [0u8; 1];
+        OsRng::fill_bytes(&mut OsRng, &mut random_byte);
+        let circuit = StandardPlonk(Scalar::from(random_byte[0] as u64));
+
+        let params = ParamsKZG::<Bls12>::unsafe_setup(k, OsRng);
+        let vk = keygen_vk_with_k::<_, KZGCommitmentScheme<Bls12>, _>(&params, &circuit, k)
+            .expect("vk should not fail");
+        let pk = keygen_pk(vk, &circuit).expect("pk should not fail");
+
+        let instances: &[&[Scalar]] = &[&[circuit.0]];
+        let mut transcript = CircuitTranscript::<State>::init();
+
+        create_proof::<Scalar, KZGCommitmentScheme<Bls12>, _, _>(
+            &params,
+            &pk,
+            &[circuit.clone()],
+            &[instances],
+            OsRng,
+            &mut transcript,
+        )
+        .expect("proof generation should not fail");
+
+        let circuit_model =
+            from_circuit_to_circuit_model::<_, _, 48, 32>(Some(k), &circuit, instances[0].len());
+
+        let proof = transcript.finalize();
+
+        assert_eq!(circuit_model.size, proof.len());
+    }
+}

--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -204,9 +204,8 @@ impl CostOptions {
         // Vanishing argument:
         // - COMM bytes for random poly
         // - (max_deg - 1) COMM bytes for the pieces
-        // - (max_deg - 1) * SCALAR bytes for pieces eval
         // - SCALAR bytes for random piece eval
-        let vanishing = comp_bytes(self.max_degree, self.max_degree);
+        let vanishing = comp_bytes(self.max_degree, 1);
 
         // Multiopening argument:
         // - COMM bytes for f_commitment

--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -33,9 +33,6 @@ struct CostOptions {
     /// A fixed column with the given rotations. May be repeated.
     fixed: Vec<Poly>,
 
-    /// Maximum degree of the custom gates.
-    gate_degree: usize,
-
     /// Maximum degree of the constraint system.
     max_degree: usize,
 
@@ -91,7 +88,7 @@ impl Lookup {
         // - input commitments at x and x_inv
         // - table commitments at x
         let product = "0,1".parse().unwrap();
-        let input = "0,-1".parse().unwrap();
+        let input = "-1,0".parse().unwrap();
         let table = "0".parse().unwrap();
 
         iter::empty()
@@ -104,25 +101,24 @@ impl Lookup {
 /// Number of permutation enabled columns
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct Permutation {
+    chunk_len: usize,
     columns: usize,
+    u: isize,
 }
 
 impl Permutation {
     /// Returns the queries of the Permutation argument
     fn queries(&self) -> impl Iterator<Item = Poly> {
-        // - product commitments at x and x_inv
-        // - polynomial commitments at x
-        let product = "0,-1".parse().unwrap();
-        let poly = "0".parse().unwrap();
+        // - at wX, X, uwX for all (except the last)
+        // - at wX, X for the last
+        let mut chunks: Poly = "0,1".parse().unwrap();
+        chunks.rotations.push(self.u);
+
+        let last_chunk: Poly = "0,1".parse().unwrap();
 
         iter::empty()
-            .chain(Some(product))
-            .chain(iter::repeat(poly).take(self.columns))
-    }
-
-    /// Returns the number of columns of the Permutation argument
-    fn nr_columns(&self) -> usize {
-        self.columns
+            .chain(iter::repeat(chunks).take((self.columns - 1) / self.chunk_len))
+            .chain(Some(last_chunk))
     }
 }
 
@@ -152,12 +148,15 @@ pub struct CircuitModel {
     pub point_sets: usize,
     /// Size of the proof for the circuit
     pub size: usize,
+    /// Compressed rows count, accounting for compression (where multiple
+    /// regions can use the same rows).
+    pub compressed_rows_count: usize,
 }
 
 impl CostOptions {
     /// Convert [CostOptions] to [CircuitModel]. The proof sizè is computed depending on the base
     /// and scalar field size of the curve used, together with the [CommitmentScheme].
-    fn into_circuit_model<const COMM: usize, const SCALAR: usize>(&self) -> CircuitModel {
+    fn into_circuit_model<const COMM: usize, const SCALAR: usize>(self) -> CircuitModel {
         let mut queries: Vec<_> = iter::empty()
             .chain(self.advice.iter())
             .chain(self.instance.iter())
@@ -184,7 +183,9 @@ impl CostOptions {
         // - SCALAR bytes per fixed per query <- missing
         // - SCALAR bytes per permutation column
         // - 5 * SCALAR bytes per lookup argument
-        let nb_perm_chunks = ((self.permutation.columns - 1) / (self.max_degree - 2)) + 1;
+        let nb_perm_chunks = ((self.permutation.columns.saturating_sub(1))
+            / (self.max_degree.saturating_sub(2)))
+            + 1;
         let plonk = comp_bytes(1, 0) * self.advice.len()
             + self
                 .advice
@@ -197,7 +198,7 @@ impl CostOptions {
                 .map(|polys| comp_bytes(0, polys.rotations.len()))
                 .sum::<usize>()
             + comp_bytes(3, 5) * self.lookup.len()
-            + comp_bytes(1, 3) * nb_perm_chunks
+            + (comp_bytes(1, 3) * nb_perm_chunks).saturating_sub(comp_bytes(0, 1)) // we don't need the permutation_product_last_eval of the last chunk
             + comp_bytes(0, 1) * self.permutation.columns;
 
         // Vanishing argument:
@@ -239,6 +240,7 @@ impl CostOptions {
             column_queries,
             point_sets,
             size,
+            compressed_rows_count: self.compressed_rows_count,
         }
     }
 }
@@ -284,10 +286,11 @@ fn from_circuit_to_cost_model_options<F: Ord + Field + FromUniformBytes<64>, C: 
     };
 
     let advice = {
-        // init the advice polynomials with no rotations
+        // init the advice polynomials with at least X as a rotation (always opens at least once)
         let mut advice = vec![Poly { rotations: vec![] }; cs.num_advice_columns()];
         for (col, rot) in cs.advice_queries() {
             advice[col.index()].rotations.push(rot.0 as isize);
+            advice[col.index()].rotations.sort()
         }
         advice
     };
@@ -297,6 +300,7 @@ fn from_circuit_to_cost_model_options<F: Ord + Field + FromUniformBytes<64>, C: 
         let mut instance = vec![Poly { rotations: vec![] }; cs.num_instance_columns()];
         for (col, rot) in cs.instance_queries() {
             instance[col.index()].rotations.push(rot.0 as isize);
+            instance[col.index()].rotations.sort()
         }
         instance
     };
@@ -304,15 +308,10 @@ fn from_circuit_to_cost_model_options<F: Ord + Field + FromUniformBytes<64>, C: 
     let lookup = { cs.lookups().iter().map(|_| Lookup).collect::<Vec<_>>() };
 
     let permutation = Permutation {
+        chunk_len: cs.degree() - 2,
         columns: cs.permutation().get_columns().len(),
+        u: -((cs.blinding_factors() + 1) as isize),
     };
-
-    let gate_degree = cs
-        .gates
-        .iter()
-        .flat_map(|gate| gate.polynomials().iter().map(|poly| poly.degree()))
-        .max()
-        .unwrap_or(0);
 
     // Note that this computation does't assume that `regions` is already in
     // order of increasing row indices.
@@ -358,7 +357,6 @@ fn from_circuit_to_cost_model_options<F: Ord + Field + FromUniformBytes<64>, C: 
         advice,
         instance,
         fixed,
-        gate_degree,
         max_degree: cs.degree(),
         lookup,
         permutation,

--- a/src/dev/cost_model.rs
+++ b/src/dev/cost_model.rs
@@ -732,6 +732,7 @@ mod tests {
         q_c: Column<Fixed>,
         q_ab: Column<Fixed>,
         constant: Column<Fixed>,
+        #[allow(dead_code)]
         instance: Column<Instance>,
         table_selector: Selector,
         table: TableColumn,

--- a/src/plonk/error.rs
+++ b/src/plonk/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
     /// An error relating to a lookup table.
     TableError(TableError),
     /// The SRS provided does not have the correct size for the Circuit
-    SrsError,
+    SrsError(usize, usize),
 }
 
 impl From<io::Error> for Error {
@@ -82,7 +82,7 @@ impl fmt::Display for Error {
                 "Column {column:?} must be included in the permutation. Help: try applying `meta.enable_equalty` on the column",
             ),
             Error::TableError(error) => write!(f, "{error}"),
-            Error::SrsError => write!(f, "The SRS provided for the given circuit does not match its size")
+            Error::SrsError(srs_k, circuit_k) => write!(f, "The SRS (with size {srs_k}) does not match for the given circuit (of size {circuit_k})")
         }
     }
 }

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -259,7 +259,7 @@ where
     let k = k_from_circuit(circuit);
 
     if params.max_k() != k {
-        return Err(Error::SrsError);
+        return Err(Error::SrsError(params.max_k() as usize, k as usize));
     }
 
     keygen_vk_with_k(params, circuit, k)

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -213,12 +213,16 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> VerifyingK
         buffer.push(*k as u8);
         buffer.extend_from_slice(&(vk.fixed_commitments.len() as u32).to_le_bytes());
         for commitment in &vk.fixed_commitments {
-            buffer.extend_from_slice(&commitment.to_raw_bytes())
+            commitment
+                .write(&mut buffer, SerdeFormat::RawBytesUnchecked)
+                .expect("Failed to write to buffer - this is a bug.");
         }
 
         buffer.extend_from_slice(&(vk.permutation.commitments().len() as u32).to_le_bytes());
         for commitment in vk.permutation.commitments() {
-            buffer.extend_from_slice(&commitment.to_raw_bytes())
+            commitment
+                .write(&mut buffer, SerdeFormat::RawBytesUnchecked)
+                .expect("Failed to write to buffer - this is a bug.");
         }
 
         // We use the debug implementation to add the gates and domain to the hashed buffer.

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -225,7 +225,6 @@ impl<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentScheme<F>> Evaluated<
         iter::empty()
             .chain(self.sets.iter().flat_map(move |set| {
                 iter::empty()
-                    // Open permutation product commitments at x and \omega^{-1} x
                     // Open permutation product commitments at x and \omega x
                     .chain(Some(VerifierQuery::new(
                         x,

--- a/src/poly/kzg/mod.rs
+++ b/src/poly/kzg/mod.rs
@@ -353,14 +353,13 @@ mod tests {
         verify::<Bn256, CircuitTranscript<Blake2bState>>(&verifier_params, &proof[..], true);
     }
 
-    fn verify<E: MultiMillerLoop, T: Transcript>(
-        verifier_params: &ParamsVerifierKZG<E>,
-        proof: &[u8],
-        should_fail: bool,
-    ) where
+    fn verify<E, T>(verifier_params: &ParamsVerifierKZG<E>, proof: &[u8], should_fail: bool)
+    where
+        E: MultiMillerLoop,
+        T: Transcript,
         E::Fr: Hashable<T::Hash> + Sampleable<T::Hash> + Ord,
-        E::G1: SerdeObject + Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr>,
-        E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
+        E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
+        E::G1Affine: CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1> + SerdeObject,
     {
         let mut transcript = T::init_from_bytes(proof);
 
@@ -400,12 +399,13 @@ mod tests {
         }
     }
 
-    fn create_proof<E: MultiMillerLoop, T: Transcript>(kzg_params: &ParamsKZG<E>) -> Vec<u8>
+    fn create_proof<E, T>(kzg_params: &ParamsKZG<E>) -> Vec<u8>
     where
+        E: MultiMillerLoop,
+        T: Transcript,
         E::Fr: WithSmallOrderMulGroup<3> + Hashable<T::Hash> + Sampleable<T::Hash> + Ord,
+        E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr, AffineExt = E::G1Affine>,
         E::G1Affine: SerdeObject + CurveAffine<ScalarExt = E::Fr, CurveExt = E::G1>,
-
-        E::G1: Hashable<T::Hash> + CurveExt<ScalarExt = E::Fr> + SerdeObject + Default,
     {
         let k = (kzg_params.g.len() - 1).ilog2() + 1;
         let domain = EvaluationDomain::new(1, k);

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -5,6 +5,7 @@ use ff::PrimeField;
 use group::{Curve, GroupEncoding};
 use halo2curves::serde::SerdeObject;
 use std::io;
+use std::io::{Read, Write};
 
 /// This enum specifies how various types are serialized and deserialized.
 #[derive(Clone, Copy, Debug)]
@@ -23,7 +24,7 @@ pub enum SerdeFormat {
 }
 
 /// Interface for Serde objects that can be represented in compressed form.
-pub trait ProcessedSerdeObject: SerdeObject + Default {
+pub trait ProcessedSerdeObject: GroupEncoding {
     /// Reads an element from the buffer and parses it according to the `format`:
     /// - `Processed`: Reads a compressed element and decompress it
     /// - `RawBytes`: Reads an uncompressed element and checks its correctness
@@ -37,10 +38,10 @@ pub trait ProcessedSerdeObject: SerdeObject + Default {
 }
 
 /// Byte length of an affine curve element according to `format`.
-pub fn byte_length<T: ProcessedSerdeObject + Default>(format: SerdeFormat) -> usize {
+pub fn byte_length<T: ProcessedSerdeObject>(format: SerdeFormat) -> usize {
     match format {
-        SerdeFormat::Processed => T::default().to_raw_bytes().len(),
-        _ => T::default().to_raw_bytes().len() * 2,
+        SerdeFormat::Processed => <T as GroupEncoding>::Repr::default().as_ref().len(),
+        _ => <T as GroupEncoding>::Repr::default().as_ref().len() * 2,
     }
 }
 
@@ -58,33 +59,44 @@ pub(crate) fn read_f<F: PrimeField + SerdeObject, R: io::Read>(
 }
 
 /// Trait for serialising SerdeObjects
-impl<C: Curve + SerdeObject + Default + GroupEncoding> ProcessedSerdeObject for C {
+impl<C> ProcessedSerdeObject for C
+where
+    C: Curve + Default + GroupEncoding + From<C::AffineRepr>,
+    C::AffineRepr: SerdeObject,
+{
     /// Reads an element from the buffer and parses it according to the `format`:
     /// - `Processed`: Reads a compressed curve element and decompress it
     /// - `RawBytes`: Reads an uncompressed curve element with coordinates in Montgomery form.
     ///   Checks that field elements are less than modulus, and then checks that the point is on the curve.
     /// - `RawBytesUnchecked`: Reads an uncompressed curve element with coordinates in Montgomery form;
     ///   does not perform any checks
-    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
-        match format {
-            SerdeFormat::Processed => {
-                let mut compressed = <Self as GroupEncoding>::Repr::default();
-                reader.read_exact(compressed.as_mut())?;
-                Option::from(Self::from_bytes(&compressed)).ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::Other, "Invalid point encoding in proof")
-                })
+    fn read<R: Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+        {
+            match format {
+                SerdeFormat::Processed => {
+                    let mut compressed = <Self as GroupEncoding>::Repr::default();
+                    reader.read_exact(compressed.as_mut())?;
+                    Option::from(Self::from_bytes(&compressed)).ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::Other, "Invalid point encoding in proof")
+                    })
+                }
+                SerdeFormat::RawBytes => {
+                    <Self as Curve>::AffineRepr::read_raw(reader).map(|p| p.into())
+                }
+                SerdeFormat::RawBytesUnchecked => {
+                    Ok(<Self as Curve>::AffineRepr::read_raw_unchecked(reader).into())
+                }
             }
-            SerdeFormat::RawBytes => <Self as SerdeObject>::read_raw(reader),
-            SerdeFormat::RawBytesUnchecked => Ok(<Self as SerdeObject>::read_raw_unchecked(reader)),
         }
     }
+
     /// Writes a curve element according to `format`:
     /// - `Processed`: Writes a compressed curve element
     /// - Otherwise: Writes an uncompressed curve element with coordinates in Montgomery form
-    fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
+    fn write<W: Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         match format {
             SerdeFormat::Processed => writer.write_all(self.to_bytes().as_ref()),
-            _ => self.write_raw(writer),
+            _ => self.to_affine().write_raw(writer),
         }
     }
 }


### PR DESCRIPTION
The fixed columns now include the permutation fixed columns. Before they only contained fixed columns, selectors, and tables.

The proof size has also been fixed.

We no longer expose CostOptions, which is only used to compute the CostModel.